### PR TITLE
Update BasicCourseFields.tsx

### DIFF
--- a/src/components/courses/form-utils/BasicCourseFields.tsx
+++ b/src/components/courses/form-utils/BasicCourseFields.tsx
@@ -48,7 +48,7 @@ export const BasicCourseFields: React.FC<BasicCourseFieldsProps> = ({ form }) =>
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-medium">Basic Information</h3>
-      
+
       <FormField
         control={form.control}
         name="title"
@@ -63,7 +63,7 @@ export const BasicCourseFields: React.FC<BasicCourseFieldsProps> = ({ form }) =>
           </FormItem>
         )}
       />
-      
+
       <FormField
         control={form.control}
         name="description"
@@ -72,17 +72,17 @@ export const BasicCourseFields: React.FC<BasicCourseFieldsProps> = ({ form }) =>
           <FormItem>
             <FormLabel>Description</FormLabel>
             <FormControl>
-              <Textarea 
-                placeholder="Enter course description" 
+              <Textarea
+                placeholder="Enter course description"
                 className="h-24"
-                {...field} 
+                {...field}
               />
             </FormControl>
             <FormMessage />
           </FormItem>
         )}
       />
-      
+
       <FormField
         control={form.control}
         name="eventType"
@@ -97,10 +97,12 @@ export const BasicCourseFields: React.FC<BasicCourseFieldsProps> = ({ form }) =>
                 <EventTypeInput
                   value={newEventType}
                   onChange={setNewEventType}
-                  onAdd={() => handleAddEventType((value) => {
-                    field.onChange(value);
-                    setEventTypeAddMode(false);
-                  })}
+                  onAdd={() =>
+                    handleAddEventType((value) => {
+                      field.onChange(value);
+                      setEventTypeAddMode(false);
+                    })
+                  }
                   onCancel={() => setEventTypeAddMode(false)}
                 />
               ) : (
@@ -127,54 +129,54 @@ export const BasicCourseFields: React.FC<BasicCourseFieldsProps> = ({ form }) =>
           </FormItem>
         )}
       />
-      
+
       <FormField
         control={form.control}
         name="category"
         rules={{ required: "Category is required" }}
-        render={({ field }) => {
-          const currentCategoryExists = categories.some(c => c.value === field.value);
-
-          return (
-            <FormItem>
-              <FormLabel>Category</FormLabel>
-              <FormControl>
-                {categories.length === 0 || (field.value && !currentCategoryExists) ? (
-                  <Skeleton className="h-10 w-full" />
-                ) : categoryAddMode ? (
-                  <CategoryInput
-                    value={newCategory}
-                    onChange={setNewCategory}
-                    onAdd={() => handleAddCategory((value) => {
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Category</FormLabel>
+            <FormControl>
+              {categories.length === 0 ? (
+                <Skeleton className="h-10 w-full" />
+              ) : categoryAddMode ? (
+                <CategoryInput
+                  value={newCategory}
+                  onChange={setNewCategory}
+                  onAdd={() =>
+                    handleAddCategory((value) => {
                       field.onChange(value);
                       setCategoryAddMode(false);
-                    })}
-                    onCancel={() => setCategoryAddMode(false)}
-                  />
-                ) : (
-                  <CategorySelect
-                    categories={categories}
-                    value={field.value || ""}
-                    onValueChange={(value) => {
-                      if (value === "__add_category__") {
-                        setCategoryAddMode(true);
-                      } else {
-                        field.onChange(value);
-                      }
-                    }}
-                    onDelete={(value, e) => {
-                      if (value === field.value) {
-                        field.onChange(categories[0]?.value || "");
-                      }
-                      handleDeleteCategory(value, () => {});
-                    }}
-                  />
-                )}
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          );
-        }}
+                    })
+                  }
+                  onCancel={() => setCategoryAddMode(false)}
+                />
+              ) : !categories.some((c) => c.value === field.value) ? (
+                <Skeleton className="h-10 w-full" />
+              ) : (
+                <CategorySelect
+                  categories={categories}
+                  value={field.value || ""}
+                  onValueChange={(value) => {
+                    if (value === "__add_category__") {
+                      setCategoryAddMode(true);
+                    } else {
+                      field.onChange(value);
+                    }
+                  }}
+                  onDelete={(value, e) => {
+                    if (value === field.value) {
+                      field.onChange(categories[0]?.value || "");
+                    }
+                    handleDeleteCategory(value, () => {});
+                  }}
+                />
+              )}
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
       />
     </div>
   );


### PR DESCRIPTION
	•	Adds a second check: if the current field.value (e.g. "programming") isn’t found in categories, show a loading skeleton.
	•	Prevents cmdk from rendering CategorySelect in a mismatch state.
	•	Ensures consistent UX until both categories and the selected value are aligned.